### PR TITLE
Update flasher

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,16 @@
 Cross-platform mass flashing tool for the USB Nugget & WiFi Nugget.  
 
 ## How to Use
-1. Install [Python3](https://www.python.org/downloads/)
-2. Install `esptool.py` from a terminal:
-  ```
-  pip install esptool
-  ```
-3. Place all Nuggets in DFU mode
-4. Run the flasher to flash the test code:
-  ```
-  python3 flash.py
-  ```
-5. Replace flash.py with the firmware you want to update with, and rename it to flasher.py
-6. Run the flasher again to flash your firmware update code:
-  ```
-  python3 flash.py
-  ```
+
+To flash latest USB Nugget software, place all Nuggets in DFU mode and then run
+`make usb-nugget-latest`. The latest software version will be installed
+automatically.
+
+To flash any other binary,
+`python3 flash.py <binary>`
+
+
+If you run into any problems, check that `make flasher-deps` doesn't report any
+missing dependencies. If you think it's a problem with your binary, you can
+flash our testing binary with either `make tester` or `python3 flash.py
+tester.bin`

--- a/flash.py
+++ b/flash.py
@@ -3,15 +3,22 @@ import subprocess
 import glob
 import esptool
 import serial.tools.list_ports
+import sys
+
+if (len(sys.argv) != 2):
+        print("Usage: {} <binary>".format(sys.argv[0]))
+        exit(1)
+binary = sys.argv[1]
+
 ports = serial.tools.list_ports.comports()
+print("Found {} devices to flash".format(len(ports)))
 
 processes = []
-
 for port, desc, hwid in sorted(ports):
         
         if ("303A:0002" in hwid):
                 print("ESP32-S2 found on port: {}".format(port))
-                proc = subprocess.Popen(["esptool.py --port {} --after no_reset write_flash 0x0 tester.bin".format(port)],shell=True)
+                proc = subprocess.Popen(["esptool.py --port {} --after no_reset write_flash 0x0 {}".format(port, binary)],shell=True)
                 processes.append(proc)
 for p in processes:
         p.wait()

--- a/makefile
+++ b/makefile
@@ -1,0 +1,19 @@
+USB_NUGGET_FILE_NAME=USB-Nugget.bin
+
+usb-nugget-latest: flasher-deps download-latest-usb-nugget
+	python3 flash.py $(USB_NUGGET_FILE_NAME)
+
+tester: flasher-deps
+	python3 flash.py tester.bin
+
+download-latest-usb-nugget: wget
+	# download latest version, or don't if we already have it
+	wget --timestamping 'https://github.com/HakCat-Tech/USB-Nugget/releases/latest/download/$(USB_NUGGET_FILE_NAME)'
+
+flasher-deps:
+	@which python3 > /dev/null || echo 'python3 not installed'
+	@which esptool.py > /dev/null || echo 'esptool.py not installed. Run `pip3 install esptool`.'
+
+wget:
+	@which wget > /dev/null || echo 'wget not installed'
+


### PR DESCRIPTION
1. Make `flasher.py` require a single command line argument -- the binary to flash
2. Added makefile to make mass flashing the latest USB-Nugget software a one-liner (`make usb-nugget-latest`)